### PR TITLE
Add gh link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-URL: https://kenjisato.github.io/juicedown/
+URL: https://kenjisato.github.io/juicedown/, https://github.com/kenjisato/juicedown
+BugReports: https://github.com/kenjisato/juicedown/issues
 Suggests: 
     readxl,
     testthat (>= 3.0.0)


### PR DESCRIPTION
You may want to consider correcting the link on the gh homepage as well. It currently says juicydown, and takes you to absent gh pages
![image](https://github.com/kenjisato/juicedown/assets/52606734/babe51c9-ab13-4ff0-a27e-a95300a2b4bd)
